### PR TITLE
Adding support for multiple case class constructors.

### DIFF
--- a/src/main/scala/jacks/case.scala
+++ b/src/main/scala/jacks/case.scala
@@ -27,7 +27,7 @@ class CaseClassSerializer(t: JavaType, accessors: Array[Accessor]) extends StdSe
   }
 }
 
-class CaseClassDeserializer(c: Constructor[_], accessors: Array[Accessor]) extends JsonDeserializer[Any] {
+class CaseClassDeserializer(t: JavaType, accessors: Array[Accessor]) extends JsonDeserializer[Any] {
   val fields = accessors.map(a => a.name -> None).toMap[String, Option[Object]]
   val types  = accessors.map(a => a.name -> a.`type`).toMap
 
@@ -60,7 +60,11 @@ class CaseClassDeserializer(c: Constructor[_], accessors: Array[Accessor]) exten
         case None    => default(a)
       }
     }
-
+    
+    val c = t.getRawClass().getConstructors().find { c => c.getParameterTypes().length == params.length }.getOrElse {
+      throw new JsonMappingException("Unable to find a case accessor for " + t.getRawClass.getName)
+    }
+    
     c.newInstance(params: _*)
   }
 

--- a/src/main/scala/jacks/module.scala
+++ b/src/main/scala/jacks/module.scala
@@ -68,7 +68,7 @@ class ScalaDeserializers extends Deserializers.Base {
     } else if (classOf[Product].isAssignableFrom(cls)) {
       ScalaTypeSig(cfg.getTypeFactory, t) match {
         case Some(sts) if sts.isCaseClass =>
-          new CaseClassDeserializer(sts.constructor, sts.accessors)
+          new CaseClassDeserializer(t, sts.accessors)
         case _ =>
           null
       }


### PR DESCRIPTION
For my Object-Database mapper, I need to provide a default constructor, which can be private. Somehow, this is the constructor ScalaTypeSig selects, and this obviously results in an error.
I added a simple construction for selecting the right constructor based on the number of parameters. This of course can ben improved, but it works for now.
