### PR TITLE
Constructor selection still needs a length check

### DIFF
--- a/src/main/scala/jacks/module.scala
+++ b/src/main/scala/jacks/module.scala
@@ -148,8 +148,9 @@ class ScalaTypeSig(val tf: TypeFactory, val `type`: JavaType, val sig: ScalaSig)
   def isCaseClass = cls.isCase
   def constructor: Constructor[_] = {
     val types = accessors.map(_.`type`.getRawClass)
-    `type`.getRawClass.getDeclaredConstructors.find {
-      _.getParameterTypes.zip(types).forall { case (a, b) => a.isAssignableFrom(b) }
+    `type`.getRawClass.getDeclaredConstructors.find { c =>
+      c.getParameterTypes().length == types.length &&
+      c.getParameterTypes.zip(types).forall { case (a, b) => a.isAssignableFrom(b) }
     }.get
   }
 


### PR DESCRIPTION
Because otherwise, an empty constructor which is first in getDeclaredConstructors() will match (which it shouldn't).
