### PR TITLE
Avoid building case classes with nulls

### DIFF
--- a/src/main/scala/jacks/case.scala
+++ b/src/main/scala/jacks/case.scala
@@ -70,7 +70,11 @@ class CaseClassDeserializer(t: JavaType, c: Creator) extends JsonDeserializer[An
     val params = c.accessors.map { a =>
       values(a.name) match {
         case Some(v) => v
-        case None    => c.default(a)
+        case None    => {
+          if (c.hasNoDefault(a))
+            throw ctx.mappingException("Required property '"+a.name+"' is missing.")
+          c.default(a)
+        }
       }
     }
 
@@ -82,6 +86,7 @@ trait Creator {
   val accessors: Array[Accessor]
   def apply(args: Seq[AnyRef]): Any
   def default(a: Accessor): AnyRef
+  def hasNoDefault(a: Accessor) = a.default == None
 }
 
 class ConstructorCreator(c: Constructor[_], val accessors: Array[Accessor]) extends Creator {


### PR DESCRIPTION
When de-serializing a case class, a case class containing 'nulls' may be built if no property is found that matches a field name. This change introduces an explicit check, and a message will be emitted in case a property is missing.

If the user intends to really build a case class containing nulls when no property is found, that can still be accomplished by using default parameters, as in: `case class a(b:String=null)`
