### PR TITLE
Add Seq support

### DIFF
--- a/src/main/scala/jacks/module.scala
+++ b/src/main/scala/jacks/module.scala
@@ -280,6 +280,7 @@ object ScalaTypeSig {
     "scala.Predef.Set"        -> classOf[Set[_]],
     "scala.Predef.String"     -> classOf[String],
     "scala.package.List"      -> classOf[List[_]],
+    "scala.package.Seq"       -> classOf[Seq[_]],
     "scala.Enumeration.Value" -> classOf[Enumeration$Val]
   ).withDefault(Class.forName(_))
 


### PR DESCRIPTION
An error message may be encountered while de-serializing a case class containing a `Seq`, for instance: `case class a(b:Seq[String])`. This commit adds `Seq` to the list of allowed collections.
