### PR TITLE
Added <empty>. as a possible path for names of classes in the lookup

### DIFF
--- a/src/main/scala/jacks/module.scala
+++ b/src/main/scala/jacks/module.scala
@@ -163,9 +163,14 @@ class ScalaTypeSig(val tf: TypeFactory, val `type`: JavaType, val sig: ScalaSig)
 
   val cls = {
     val name = `type`.getRawClass.getCanonicalName.replace('$', '.')
-    sig.symbols.collectFirst {
+    val emptyName = "<empty>." + name
+    (sig.symbols.collectFirst {
       case c:ClassSymbol if c.path == name => c
-    }.get
+    } orElse {
+      sig.symbols.collectFirst {
+        case c:ClassSymbol if c.path == emptyName => c
+      }
+    }).get
   }
 
   def isCaseClass = cls.isCase


### PR DESCRIPTION
I started using Jacks for a project: https://github.com/BitFunding/BitFunding.org and wanted to import some settings written in JSON. So in the file https://github.com/BitFunding/BitFunding.org/blob/master/src/main/scala/ScalatraBootstrap.scala

I defined a case class that looks like the following:

case class NP(v : String)

Since that file is not in any package, when I loaded the project in the scala shell, the Json parser failed because the name of the class was prefixed with "<empty>.":

scala> JacksMapper.writeValueAsString(new NP("k"))
java.util.NoSuchElementException: None.get
    at scala.None$.get(Option.scala:313)
    at scala.None$.get(Option.scala:311)
    at com.lambdaworks.jacks.ScalaTypeSig.<init>(module.scala:173)
    at com.lambdaworks.jacks.ScalaTypeSig$.apply(module.scala:303)
    at com.lambdaworks.jacks.ScalaSerializers.findSerializer(module.scala:136)
...

Below is the code snippet I ran inside the shell to nail down the problem. So I added "<empty>." as a last option for the class lookup (as a separate alternative instead of using the same case branch because I guess this should be the last option). I just intended to point the issue and provide a solution, but feel free to change it and make it more elegant. I have been coding Scala for a week and if I compare my fix to the Haskell code I normally write, I am sure there is more elegant syntax in Scala to deal with this. 

scala> import com.lambdaworks.jacks._
import com.lambdaworks.jacks._

scala> def mainFest[T](implicit m : Manifest[T]) = m
mainFest: [T](implicit m: Manifest[T])Manifest[T]

scala> val jt = JacksMapper.resolve(mainFest[NP])
jt: com.fasterxml.jackson.databind.JavaType = [simple type, class NP]

val s = ScalaSigParser.parse(jt.getRawClass).get

scala> s.symbols.collectFirst {case c => c.path}
res5: Option[String] = Some(<empty>.NP)
