### PR TITLE
Make case class serialization more robust

### DIFF
--- a/src/main/scala/jacks/module.scala
+++ b/src/main/scala/jacks/module.scala
@@ -161,10 +161,12 @@ class ScalaTypeSig(val tf: TypeFactory, val `type`: JavaType, val sig: ScalaSig)
   import tools.scalap.scalax.rules.scalasig.{Method => _,  _}
   import ScalaTypeSig.findClass
 
+  def path(c:ClassSymbol) = c.path.replaceFirst("^<empty>\\.", "")
+
   val cls = {
     val name = `type`.getRawClass.getCanonicalName.replace('$', '.')
     sig.symbols.collectFirst {
-      case c:ClassSymbol if c.path == name => c
+      case c:ClassSymbol if path(c) == name && !c.isModule => c
     }.get
   }
 

--- a/src/test/scala/jacks/test.scala
+++ b/src/test/scala/jacks/test.scala
@@ -1,6 +1,8 @@
 // Copyright (C) 2011 - Will Glozer.  All rights reserved.
 
-package com.lambdaworks.jacks
+case class Point(x: Int, y: Int)
+
+package com.lambdaworks.jacks {
 
 import com.fasterxml.jackson.annotation._
 import com.fasterxml.jackson.annotation.JsonInclude.Include
@@ -88,6 +90,10 @@ object Outer {
 case class NamingStrategy(camelCase: String, PascalCase: Int)
 
 case class WithAny(map: Map[String, Any])
+
+object ObjectBeforeCaseClass
+
+case class ObjectBeforeCaseClass(x: Int)
 
 class CaseClassSuite extends JacksTestSuite {
   test("primitive types correct") {
@@ -215,6 +221,17 @@ class CaseClassSuite extends JacksTestSuite {
     val map = Map[String, Any]("foo" -> 1, "bar" -> "2")
     rw(WithAny(map)) should equal (WithAny(map))
   }
+
+  test("Works correctly when companion object is before the case class") {
+    val obcc = ObjectBeforeCaseClass(5)
+    rw(obcc) should equal (obcc)
+  }
+
+  test("Works correctly when case class is in root package") {
+    val point = Point(5, 7)
+    rw(point) should equal (point)
+  }
+
 }
 
 class InvalidJsonSuite extends JacksTestSuite {
@@ -298,3 +315,6 @@ trait JacksTestSuite extends FunSuite with Matchers {
   def write[T: Manifest](v: T)     = writeValueAsString(v)
   def read[T: Manifest](s: String) = readValue(s)
 }
+
+}
+


### PR DESCRIPTION
This contains fixes and tests to address two issues with case class serialization in jacks.

First, case classes in the root package cannot be serialized. This is because their scalap ClassSymbol names are prefixed with "&lt;empty&gt;.", which prevents them from being seen as the correct class in the jacks Scala module.

Second, jacks fails to correctly serialize case classes with a user-defined companion object, if that companion object is defined before the case class in the .scala file that contains them (companion objects have to be in the same file as the class to which they are a companion). This is because jacks simply finds the first scalap ClassSymbol from the file whose name matches the class name from the JavaType being serialized without checking whether that ClassSymbol is for the companion object.
